### PR TITLE
[CBP-35482] Replace all references from platform to Unify

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ To learn more about organizing your artifacts using labels, refer to link:https:
 
 == Prerequisites
 
-Set up CloudBees Unify and GHA to work together, providing key features of the platform to GHA workflows.
+Set up CloudBees Unify and GHA to work together, providing key features of Unify to GHA workflows.
 Refer to link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/github-actions/gha-getting-started[Getting started with GHA integration] for more information.
 
 == Inputs
@@ -108,7 +108,7 @@ jobs:
       contents: read
     steps:
 
-      - name: Register Build Artifact in Cloudbees Platform
+      - name: Register Build Artifact in CloudBees Unify
         uses: cloudbees-io-gha/register-build-artifact@v3
         id: go-action
         with:
@@ -139,7 +139,7 @@ jobs:
 ----
 --
 
-After the run has completed, the artifact label is updated from "For testing" to "For production" for the given artifact version, and the label is displayed in the Artifacts list tab in the platform.
+After the run has completed, the artifact label is updated from "For testing" to "For production" for the given artifact version, and the label is displayed in the Artifacts list tab in Unify.
 
 == License
 


### PR DESCRIPTION
This PR updates all remaining references from 'platform' to 'Unify' to ensure consistent terminology across documentation.